### PR TITLE
Fix Query/Output object

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,7 @@ describe('cypher', () => {
   it('should provide the query with the replaced parameters', () => {
     expect(template).toEqual(
       expect.objectContaining({
-        query: 'a $p_0 b $p_1 c $p_2 d $p_3 e $p_4 f $p_5 g',
+        text: 'a $p_0 b $p_1 c $p_2 d $p_3 e $p_4 f $p_5 g',
       }),
     );
   });
@@ -17,7 +17,7 @@ describe('cypher', () => {
   it('should provide parameters to match the query', () => {
     expect(template).toEqual(
       expect.objectContaining({
-        params: {
+        parameters: {
           p_0: 1,
           p_1: 'str',
           p_2: [1, 2],
@@ -30,17 +30,17 @@ describe('cypher', () => {
   });
 
   it('should return empty params when no expressions', () => {
-    expect(cypher`no params`).toEqual({ query: 'no params', params: {} });
+    expect(cypher`no params`).toEqual({ text: 'no params', parameters: {} });
   });
 
   it('should handle nested cypher templates', () => {
     expect(cypher`a = ${1}, ${cypher`then ${2} ${cypher`and finally ${3}`} with sibling ${4}`}`).toEqual({
-      query: 'a = $p_0, then $p_1 and finally $p_2 with sibling $p_3',
-      params: { p_0: 1, p_1: 2, p_2: 3, p_3: 4 },
+      text: 'a = $p_0, then $p_1 and finally $p_2 with sibling $p_3',
+      parameters: { p_0: 1, p_1: 2, p_2: 3, p_3: 4 },
     })
   })
 
   it('should not include undefined or null expressions', () => {
-    expect(cypher`test ${undefined}${null}`).toEqual({ query: 'test ', params: {} })
+    expect(cypher`test ${undefined}${null}`).toEqual({ text: 'test ', parameters: {} })
   })
 });


### PR DESCRIPTION
The keys for the query object in the `neo4j-driver` are `text` and `parameters` instead of `query` and `params`.

See:
https://github.com/neo4j/neo4j-javascript-driver/blob/89a89725d92f9468a45cd57462413a2091311b0b/packages/core/src/session.ts#L137
https://github.com/neo4j/neo4j-javascript-driver/blob/89a89725d92f9468a45cd57462413a2091311b0b/packages/core/src/types.ts#L23
https://github.com/neo4j/neo4j-javascript-driver/blob/89a89725d92f9468a45cd57462413a2091311b0b/packages/core/src/internal/util.ts#L67